### PR TITLE
implements index name for elastic-search

### DIFF
--- a/Serilog.Sinks.LogstashHttp/LoggerConfigurationLogstashHttpExtensions.cs
+++ b/Serilog.Sinks.LogstashHttp/LoggerConfigurationLogstashHttpExtensions.cs
@@ -44,18 +44,20 @@ namespace Serilog
         /// </summary>
         /// <param name="loggerSinkConfiguration">Options for the sink.</param>
         /// <param name="logstashUri">URI for Logstash.</param>
+        /// <param name="indexName">Index name for ElasticSearch </param>
         /// <returns>LoggerConfiguration object</returns>
         /// <exception cref="ArgumentNullException"><paramref name="logstashUri" /> is <see langword="null" />.</exception>
         public static LoggerConfiguration LogstashHttp(
             this LoggerSinkConfiguration loggerSinkConfiguration,
-            string logstashUri)
+            string logstashUri, string indexName = null)
         {
             if (string.IsNullOrEmpty(logstashUri))
                 throw new ArgumentNullException(nameof(logstashUri), "No Logstash uri specified.");
 
             var options = new LogstashHttpSinkOptions
             {
-                LogstashUri = logstashUri
+                LogstashUri = logstashUri,
+                IndexName = indexName
             };
 
             return LogstashHttp(loggerSinkConfiguration, options);

--- a/Serilog.Sinks.LogstashHttp/Sinks/LogstashHttp/DefaultJsonFormatter.cs
+++ b/Serilog.Sinks.LogstashHttp/Sinks/LogstashHttp/DefaultJsonFormatter.cs
@@ -37,6 +37,7 @@ namespace Serilog.Sinks.LogstashHttp
         private readonly IDictionary<Type, Action<object, bool, TextWriter>> _literalWriters;
         private readonly bool _omitEnclosingObject;
         private readonly bool _renderMessage;
+        private readonly string _indexName;
 
         /// <summary>
         ///     Construct a <see cref="DefaultJsonFormatter" />.
@@ -56,16 +57,19 @@ namespace Serilog.Sinks.LogstashHttp
         ///     property named RenderedMessage.
         /// </param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <param name="indexName">When set index value will be written at the root of the json document</param>
         protected DefaultJsonFormatter(
             bool omitEnclosingObject = false,
             string closingDelimiter = null,
             bool renderMessage = false,
-            IFormatProvider formatProvider = null)
+            IFormatProvider formatProvider = null,
+            string indexName = null)
         {
             _omitEnclosingObject = omitEnclosingObject;
             _closingDelimiter = closingDelimiter ?? Environment.NewLine;
             _renderMessage = renderMessage;
             _formatProvider = formatProvider;
+            _indexName = indexName;
 
             _literalWriters = new Dictionary<Type, Action<object, bool, TextWriter>>
             {
@@ -111,6 +115,7 @@ namespace Serilog.Sinks.LogstashHttp
             var delim = "";
             WriteTimestamp(logEvent.Timestamp, ref delim, output);
             WriteLevel(logEvent.Level, ref delim, output);
+            WriteIndexName(_indexName, ref delim, output);
             WriteMessageTemplate(logEvent.MessageTemplate.Text, ref delim, output);
             if (_renderMessage)
             {
@@ -245,6 +250,15 @@ namespace Serilog.Sinks.LogstashHttp
         protected virtual void WriteMessageTemplate(string template, ref string delim, TextWriter output)
         {
             WriteJsonProperty("MessageTemplate", template, ref delim, output);
+        }
+
+        /// <summary>
+        ///     Writes out the Index name
+        /// </summary>
+        protected virtual void WriteIndexName(string name, ref string delim, TextWriter output)
+        {
+            if (!string.IsNullOrEmpty(name))
+                WriteJsonProperty("index", name, ref delim, output);
         }
 
         /// <summary>

--- a/Serilog.Sinks.LogstashHttp/Sinks/LogstashHttp/LogstashHttpJsonFormatter.cs
+++ b/Serilog.Sinks.LogstashHttp/Sinks/LogstashHttp/LogstashHttpJsonFormatter.cs
@@ -46,12 +46,14 @@ namespace Serilog.Sinks.LogstashHttp
         /// </param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
         /// <param name="inlineFields">When set to true values will be written at the root of the json document</param>
+        /// <param name="indexName">When set index value will be written at the root of the json document</param>
         public LogstashHttpJsonFormatter(bool omitEnclosingObject = false,
             string closingDelimiter = null,
             bool renderMessage = false,
             IFormatProvider formatProvider = null,
-            bool inlineFields = false)
-            : base(omitEnclosingObject, closingDelimiter, renderMessage, formatProvider)
+            bool inlineFields = false,
+            string indexName = null)
+            : base(omitEnclosingObject, closingDelimiter, renderMessage, formatProvider, indexName)
         {
             _inlineFields = inlineFields;
         }
@@ -250,6 +252,14 @@ namespace Serilog.Sinks.LogstashHttp
         protected override void WriteTimestamp(DateTimeOffset timestamp, ref string delim, TextWriter output)
         {
             WriteJsonProperty("@timestamp", timestamp, ref delim, output);
+        }
+
+        /// <summary>
+        ///     Writes out the Index name
+        /// </summary>
+        protected override void WriteIndexName(string name, ref string delim, TextWriter output)
+        {
+            WriteJsonProperty("index", name, ref delim, output);
         }
     }
 }

--- a/Serilog.Sinks.LogstashHttp/Sinks/LogstashHttp/LogstashHttpSinkOptions.cs
+++ b/Serilog.Sinks.LogstashHttp/Sinks/LogstashHttp/LogstashHttpSinkOptions.cs
@@ -73,5 +73,11 @@ namespace Serilog.Sinks.LogstashHttp
         ///     Logstash Uri
         /// </summary>
         public string LogstashUri { get; set; }
+
+        /// <summary>
+        ///     Index name place holder
+        /// </summary>
+        public string IndexName { get; set; }
+
     }
 }

--- a/Serilog.Sinks.LogstashHttp/Sinks/LogstashHttp/LogstashHttpSinkState.cs
+++ b/Serilog.Sinks.LogstashHttp/Sinks/LogstashHttp/LogstashHttpSinkState.cs
@@ -27,13 +27,15 @@ namespace Serilog.Sinks.LogstashHttp
                             formatProvider: options.FormatProvider,
                             renderMessage: true,
                             closingDelimiter: string.Empty,
-                            inlineFields: options.InlineFields
+                            inlineFields: options.InlineFields,
+                            indexName: options.IndexName
                         );
             DurableFormatter = options.CustomDurableFormatter ?? new LogstashHttpJsonFormatter(
                                    formatProvider: options.FormatProvider,
                                    renderMessage: true,
                                    closingDelimiter: Environment.NewLine,
-                                   inlineFields: options.InlineFields
+                                   inlineFields: options.InlineFields,
+                                   indexName: options.IndexName
                                );
         }
 
@@ -44,7 +46,7 @@ namespace Serilog.Sinks.LogstashHttp
         public static LogstashHttpSinkState Create(LogstashHttpSinkOptions options)
         {
             if (options == null)
-                throw new ArgumentNullException("options");
+                throw new ArgumentNullException(nameof(options));
 
             return new LogstashHttpSinkState(options);
         }


### PR DESCRIPTION
Simply adds additional root level field called `index` so logstash can grab it and know which index to put the message