### PR TITLE
Added json lines batch post to logstash and content type override option

### DIFF
--- a/Serilog.Sinks.LogstashHttp/Sinks/LogstashHttp/LogstashHttpSinkOptions.cs
+++ b/Serilog.Sinks.LogstashHttp/Sinks/LogstashHttp/LogstashHttpSinkOptions.cs
@@ -30,6 +30,7 @@ namespace Serilog.Sinks.LogstashHttp
         {
             Period = TimeSpan.FromSeconds(2);
             BatchPostingLimit = 50;
+            ContentType = "application/json";
         }
 
         /// <summary>
@@ -73,5 +74,15 @@ namespace Serilog.Sinks.LogstashHttp
         ///     Logstash Uri
         /// </summary>
         public string LogstashUri { get; set; }
-    }
+
+        /// <summary>
+        ///     Enables sending the batch of events at once as json lines to logstash. Defaults to false.
+        /// </summary>
+        public bool JsonLinesBatch { get; set; }
+
+        /// <summary>
+        ///     Content-Type request header used when posting logs to logstash. Defaults to "application/json"
+        /// </summary>
+        public string ContentType { get; set; }
+  }
 }


### PR DESCRIPTION
Hello, I am happy that you created the logstash http sink. 

I would like to contribute by adding json lines batching when posting to logstash. Also, I added content type option as I found it convenient setting to be used together with logstash http input config option "additional_codecs". It allows setting codec per content type header value. 
The code change is small and non-breaking. 