### PR TITLE
Feature/queue limit

### DIFF
--- a/Serilog.Sinks.LogstashHttp.ExampleApp/Serilog.Sinks.LogstashHttp.ExampleApp.csproj
+++ b/Serilog.Sinks.LogstashHttp.ExampleApp/Serilog.Sinks.LogstashHttp.ExampleApp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Serilog.Sinks.LogstashHttp/LoggerConfigurationLogstashHttpExtensions.cs
+++ b/Serilog.Sinks.LogstashHttp/LoggerConfigurationLogstashHttpExtensions.cs
@@ -16,6 +16,7 @@ using System;
 using Serilog.Configuration;
 using Serilog.Events;
 using Serilog.Sinks.LogstashHttp;
+using Serilog.Sinks.PeriodicBatching;
 
 namespace Serilog
 {
@@ -36,7 +37,9 @@ namespace Serilog
         {
             var sink = new LogstashHttpSink(options);
 
-            return loggerSinkConfiguration.Sink(sink, options.MinimumLogEventLevel ?? LevelAlias.Minimum);
+            var periodicBatchingSink = new PeriodicBatchingSink(sink, options);
+
+            return loggerSinkConfiguration.Sink(periodicBatchingSink, options.MinimumLogEventLevel ?? LevelAlias.Minimum);
         }
 
         /// <summary>

--- a/Serilog.Sinks.LogstashHttp/Serilog.Sinks.LogstashHttp.csproj
+++ b/Serilog.Sinks.LogstashHttp/Serilog.Sinks.LogstashHttp.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="Nito.AsyncEx.Coordination" Version="1.0.2" />
     <PackageReference Include="Serilog" Version="2.4.0" />
-    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.1.0" />
+    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="3.1.0" />
   </ItemGroup>
 
 </Project>

--- a/Serilog.Sinks.LogstashHttp/Sinks/LogstashHttp/LogstashHttpSink.cs
+++ b/Serilog.Sinks.LogstashHttp/Sinks/LogstashHttp/LogstashHttpSink.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright 2017 Aleksandr Sukhodko
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,7 +29,7 @@ namespace Serilog.Sinks.LogstashHttp
     /// <summary>
     ///     Writes log events as documents to ElasticSearch.
     /// </summary>
-    public class LogstashHttpSink : PeriodicBatchingSink
+    public class LogstashHttpSink : IBatchedLogEventSink
     {
         private static readonly HttpClient HttpClient = new HttpClient();
         private static readonly AsyncLock Mutex = new AsyncLock();
@@ -43,10 +43,11 @@ namespace Serilog.Sinks.LogstashHttp
         /// Options configuring how the sink behaves, may NOT be null
         /// </param>
         public LogstashHttpSink(LogstashHttpSinkOptions options)
-            : base(options.BatchPostingLimit, options.Period)
         {
             _state = LogstashHttpSinkState.Create(options);
         }
+
+        public Task OnEmptyBatchAsync() => Task.CompletedTask;
 
         /// <summary>
         /// Emit a batch of log events, running to completion synchronously.
@@ -64,7 +65,7 @@ namespace Serilog.Sinks.LogstashHttp
         /// <returns>
         /// The <see cref="Task"/>.
         /// </returns>
-        protected override async Task EmitBatchAsync(IEnumerable<LogEvent> events)
+        public async Task EmitBatchAsync(IEnumerable<LogEvent> events)
         {
             // ReSharper disable PossibleMultipleEnumeration
             if (events == null || !events.Any()) return;

--- a/Serilog.Sinks.LogstashHttp/Sinks/LogstashHttp/LogstashHttpSinkOptions.cs
+++ b/Serilog.Sinks.LogstashHttp/Sinks/LogstashHttp/LogstashHttpSinkOptions.cs
@@ -30,6 +30,7 @@ namespace Serilog.Sinks.LogstashHttp
         {
             Period = TimeSpan.FromSeconds(2);
             BatchPostingLimit = 50;
+            ContentType = "application/json";
         }
 
         /// <summary>
@@ -73,5 +74,15 @@ namespace Serilog.Sinks.LogstashHttp
         ///     Logstash Uri
         /// </summary>
         public string LogstashUri { get; set; }
-    }
+
+        /// <summary>
+        ///     Enables sending the batch of events at once as json lines to logstash. Defaults to false.
+        /// </summary>
+        public bool JsonLinesBatch { get; set; }
+
+        /// <summary>
+        ///     Content-Type request header used when posting logs to logstash. Defaults to "application/json"
+        /// </summary>
+        public string ContentType { get; set; }
+  }
 }

--- a/Serilog.Sinks.LogstashHttp/Sinks/LogstashHttp/LogstashHttpSinkOptions.cs
+++ b/Serilog.Sinks.LogstashHttp/Sinks/LogstashHttp/LogstashHttpSinkOptions.cs
@@ -1,11 +1,11 @@
 // Copyright 2014 Serilog Contributors
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,27 +21,8 @@ namespace Serilog.Sinks.LogstashHttp
     /// <summary>
     ///     Provides ElasticsearchSink with configurable options
     /// </summary>
-    public class LogstashHttpSinkOptions
+    public class LogstashHttpSinkOptions : PeriodicBatching.PeriodicBatchingSinkOptions
     {
-        /// <summary>
-        ///     Configures the sink defaults
-        /// </summary>
-        public LogstashHttpSinkOptions()
-        {
-            Period = TimeSpan.FromSeconds(2);
-            BatchPostingLimit = 50;
-            ContentType = "application/json";
-        }
-
-        /// <summary>
-        ///     The maximum number of events to post in a single batch.
-        /// </summary>
-        public int BatchPostingLimit { get; set; }
-
-        /// <summary>
-        ///     The time to wait between checking for event batches. Defaults to 2 seconds.
-        /// </summary>
-        public TimeSpan Period { get; set; }
 
         /// <summary>
         ///     Supplies culture-specific formatting information, or null.
@@ -83,6 +64,7 @@ namespace Serilog.Sinks.LogstashHttp
         /// <summary>
         ///     Content-Type request header used when posting logs to logstash. Defaults to "application/json"
         /// </summary>
-        public string ContentType { get; set; }
-  }
+        public string ContentType { get; set; } = "application/json";
+
+    }
 }


### PR DESCRIPTION
This enables all options for PeriodicBatching to expose QueueSizeLimit, which can solve memory overflow issues when logs arrive very fast.
I also merged the changes from kalski because we wanted to really batch the request and it upgrades the PeriodicBatching package to 3.1.0.